### PR TITLE
Add error types for MySQL in strict mode

### DIFF
--- a/lib/DBIx/Class/ParseError/Parser/MySQL.pm
+++ b/lib/DBIx/Class/ParseError/Parser/MySQL.pm
@@ -9,6 +9,10 @@ with 'DBIx::Class::ParseError::Parser';
 sub type_regex {
     return {
         data_type => qr{Incorrect.+value\:.+for\s+column\s+\'(\w+)\'}i,
+	data_too_long => qr{Data too long for column \'(\w+)\'}i,
+	data_truncated => qr{Data truncated for column \'(\w+)\'}i,
+	out_of_range => qr{Out of range value for column \'(\w+)\'}i,
+	incorrect_date => qr{Incorrect date value: '.+?' for column `.+?`\.`.+?`\.`(\w+)`}i,
         missing_table => qr{()Table\s+\'.+\'\s+doesn\'t\s+exist}i,
         missing_column => qr{no\s+such\s+column\s+\'(\w+)\'}i,
         not_null => qr{


### PR DESCRIPTION
When using a schema with MySQL in strict mode:

```
  return Schema->connect(
    $dsn,
    $user,
    $pass,
    {
      on_connect_call => 'set_strict_mode'  
    }
  );
```

`DBIx::Class:::ParseError` fails to parse errors from MySQL. I have collected the exception objects thrown by DBIx::Class for each one of the types of error in this PR:

```
$VAR1 = bless( {
                 'msg' => 'DBIx::Class::Storage::DBI::_dbh_execute(): DBI Exception: DBD::mysql::st execute failed: Data too long for column \'name\' at row 1 [for Statement "INSERT INTO table ( name) VALUES ( ? )" with ParamValues: 0=\'cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc\'] at Module.pm line 108
'
               }, 'DBIx::Class::Exception' );
```

```
$VAR1 = bless( {
                 'msg' => 'DBIx::Class::Storage::DBI::_dbh_execute(): DBI Exception: DBD::mysql::st execute failed: Data truncated for column \'enum\' at row 1 [for Statement "INSERT INTO table ( date, number, id, name, enum) VALUES ( ?, ?, ?, ?, ? )" with ParamValues: 0=undef, 1=0, 2=1, 3=\'test\', 4=\'Invalid\'] at Module.pm line 76
'
               }, 'DBIx::Class::Exception' );
```

```
$VAR1 = bless( {
                 'msg' => 'DBIx::Class::Storage::DBI::_dbh_execute(): DBI Exception: DBD::mysql::st execute failed: Out of range value for column \'number\' at row 1 [for Statement "INSERT INTO table ( date, number, id, name, enum) VALUES ( ?, ?, ?, ?, ? )" with ParamValues: 0=undef, 1=80000, 2=1, 3=\'test\', 4=\'Yes\'] at Module.pm line 76
'
               }, 'DBIx::Class::Exception' );
```

```
$VAR1 = bless( {
                 'msg' => 'DBIx::Class::Storage::DBI::_dbh_execute(): DBI Exception: DBD::mysql::st execute failed: Incorrect date value: \'3099-14-31\' for column `database`.`table`.`date` at row 1 [for Statement "INSERT INTO table ( date, number, id, name, enum) VALUES ( ?, ?, ?, ?, ? )" with ParamValues: 0=\'3099-14-31\', 1=1, 2=1, 3=\'test\', 4=\'Yes\'] at Module.pm line 76
'
               }, 'DBIx::Class::Exception' );
```
